### PR TITLE
ci: fixes for Nix 2.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v14
         with:
-          nix_path: nixpkgs=channel:nixpkgs-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       - name: Check flake
-        run: |
-          nix run nixpkgs.nixUnstable -c \
-            nix --experimental-features 'nix-command flakes' flake check
+        run: nix flake check
   home-manager:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upgrade-deps.yaml
+++ b/.github/workflows/upgrade-deps.yaml
@@ -10,11 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v14
         with:
-          nix_path: nixpkgs=channel:nixpkgs-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       - name: Update flake
-        run: |
-          nix run nixpkgs.nixUnstable -c \
-            nix --experimental-features 'nix-command flakes' flake update
+        run: nix flake update
       - name: Update submodules
         run: git submodule update --init --remote
       - name: Create Pull Request

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635394434,
-        "narHash": "sha256-aOllNFaasxQalCt2D0FXrgOMsn0TZZue42uNkjH896I=",
+        "lastModified": 1636274622,
+        "narHash": "sha256-tZYuGhqcfH7piCsrUrIYM0P3oPJcoBxGkuxeFNVxkCc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "158bc593983ef26daeb9cc73fd659f64b4d1998a",
+        "rev": "2917ef23b398a22ee33fb34b5766b28728228ab1",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixos": {
       "locked": {
-        "lastModified": 1635373256,
-        "narHash": "sha256-6QERROygyZN2itA2JUZzhf+o2jfqd6ykJZHQcCAE0r4=",
+        "lastModified": 1636138231,
+        "narHash": "sha256-FZQ5wBcB9zI21uQMB/PaEQ/cLYk+Bwnig5cg1+2rPgg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d14d83a3691121642be1b0579cf3408a83c558d7",
+        "rev": "5c02380de3951d0237807c16eb19873cb3c5f75d",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1635295995,
-        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "lastModified": 1636228094,
+        "narHash": "sha256-CpOcIwHAn3yS0PeVmUICFrJ+gde2PiZp3XsnDP3LE9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "rev": "2606cb0fc24e65f489b7d9fdcbf219756e45db35",
         "type": "github"
       },
       "original": {

--- a/home/files/.config/doom/packages.el
+++ b/home/files/.config/doom/packages.el
@@ -19,9 +19,6 @@
 ;; available.
 (package! pdf-tools :built-in 'prefer)
 
-;; FIXME: Workaround for https://github.com/hlissner/doom-emacs/issues/5681
-(package! flx)
-
 ;;
 ;;; Disabled Packages
 

--- a/home/files/.docker/config.json
+++ b/home/files/.docker/config.json
@@ -1,3 +1,0 @@
-{
-  "detachKeys": "ctrl-q,d"
-}

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -2,25 +2,4 @@
 
 final: prev:
 
-prev.lib.optionalAttrs (prev.stdenv.isDarwin) {
-
-  python3 = prev.python3.override {
-    packageOverrides = final: prev: {
-      # TODO: remove temporary fix
-      #   issue https://github.com/NixOS/nixpkgs/pull/137870
-      #   status in https://nixpk.gs/pr-tracker.html?pr=137870
-      beautifulsoup4 = prev.beautifulsoup4.overridePythonAttrs (_: {
-        disabledTests = [
-          "test_real_hebrew_document"
-          "test_smart_quotes_converted_on_the_way_in"
-          "test_can_parse_unicode_document"
-        ];
-      });
-    };
-  };
-
-  python3Packages = final.python3.pkgs;
-
-  # TODO: investigate why installCheck fails
-  thefuck = prev.thefuck.overrideAttrs (_: { doInstallCheck = false; });
-}
+{ }

--- a/setup.sh
+++ b/setup.sh
@@ -113,7 +113,7 @@ source "$DOTFILE_DIR/scripts/setup"
 @shell Install Packages
   - init: true
   - nvim --headless +PlugInstall +'%print' +qall
-  - ~/.emacs.d/bin/doom -y install --no-config
+  - ~/.config/emacs/bin/doom -y install --no-config
 
 @githooks
   - init: true

--- a/setup.sh
+++ b/setup.sh
@@ -98,7 +98,6 @@ source "$DOTFILE_DIR/scripts/setup"
   - .config/ranger/scope.sh
   - .config/tilix/schemes/gruvbox-dark.json
   - .config/zathura/zathurarc
-  - .docker/config.json
   - .ipython/profile_default/ipython_config.py
   - .local/opt/fzftools
   - .local/opt/tmux-copycat


### PR DESCRIPTION
Created a PR to check the updated CI job actually works. Also inclues a few other commits that hadn't been pushed yet.

- Revert "docker: stop docker from swallowing ctrl-p"
- Revert workaround for Ivy failure in Doom Emacs
- fix(setup): incorrect path to Doom CLI
- ci: fixes for Nix 2.4
- chore(deps): routine update
